### PR TITLE
feat: add whitespace pre line to necessary elements

### DIFF
--- a/src/lib/components/atoms/title/title.svelte
+++ b/src/lib/components/atoms/title/title.svelte
@@ -66,15 +66,19 @@
 
 <div class="flex flex-col font-medium space-y-6 {positionClass} layout--{position}">
     {#if overline.length > 0}
-        <span class="{OVERLINE_TEXT} {textColorClass}">{overline} </span>
+        <span class="whitespace-pre-line {OVERLINE_TEXT} {textColorClass}">{overline}</span>
     {/if}
 
-    <svelte:element this={titleTagFallback} {id} class="{titleColorClass} {sizeClass}">
+    <svelte:element
+        this={titleTagFallback}
+        {id}
+        class="whitespace-pre-line {titleColorClass} {sizeClass}"
+    >
         {title}
     </svelte:element>
 
     {#if subtitle.length > 0}
-        <span class="{subtitleTextClass} {textColorClass}">
+        <span class="whitespace-pre-line {subtitleTextClass} {textColorClass}">
             {subtitle}
         </span>
     {/if}

--- a/src/lib/components/molecules/highlight-card/highlight-card.svelte
+++ b/src/lib/components/molecules/highlight-card/highlight-card.svelte
@@ -127,7 +127,7 @@
                     <span class="{OVERLINE_TEXT} text-white/80">{overline}</span>
                 {/if}
 
-                <h6 class="text-white text-4xl leading-44 font-medium">
+                <h6 class="whitespace-pre-line text-white text-4xl leading-44 font-medium">
                     {title}
                 </h6>
 

--- a/src/lib/components/molecules/icon-content/icon-content.svelte
+++ b/src/lib/components/molecules/icon-content/icon-content.svelte
@@ -39,7 +39,9 @@
         <Icon {icon} width={48} height={48} currentColor />
     </span>
     <div class="flex flex-col items-start space-y-4 pl-3">
-        <p class="text-2xl font-medium leading-32 {TITLE_COLORS[mode]}">{title}</p>
+        <p class="whitespace-pre-line text-2xl font-medium leading-32 {TITLE_COLORS[mode]}">
+            {title}
+        </p>
         <p class="leading-28 {DESCRIPTION_COLORS[mode]}">{description}</p>
     </div>
 </div>

--- a/src/lib/components/molecules/icon-text/icon-text.svelte
+++ b/src/lib/components/molecules/icon-text/icon-text.svelte
@@ -30,7 +30,7 @@
 <style lang="postcss">
     div {
         p {
-            @apply text-lg;
+            @apply text-lg font-medium;
         }
     }
 </style>

--- a/src/lib/components/organisms/hero/hero.svelte
+++ b/src/lib/components/organisms/hero/hero.svelte
@@ -89,7 +89,7 @@
     }
 </script>
 
-<section {id} class="min-h-screen flex items-stretch h-full bg-white relative pt-20">
+<section {id} class="min-h-screen flex items-stretch h-full bg-white relative pt-20 pb-8 sm:pb-0">
     <div class="container mx-auto self-stretch">
         {#if backgroundMedia}
             <div class="absolute inset-0 z-0">
@@ -155,14 +155,14 @@
             {#if iconFeatures.length || anchorLinks.length}
                 <div class="flex flex-col">
                     {#if iconFeatures.length}
-                        <div class="grid grid-cols-5 gap-x-12 py-6">
+                        <div class="grid grid-cols-1 sm:grid-cols-5 gap-x-12 gap-y-8 py-12 sm:py-6">
                             {#each iconFeatures as iconFeature}
                                 <IconText {...iconFeature} darkmode={componentDarkmode} />
                             {/each}
                         </div>
                     {/if}
                     {#if anchorLinks.length}
-                        <nav class="grid grid-cols-1 gap-y-4 sm:grid-cols-4">
+                        <nav class="grid grid-cols-1 gap-y-4 sm:grid-cols-4 py-6 sm:py-0">
                             {#each anchorLinks as anchorLink}
                                 <AnchorLink {...anchorLink} darkmode={componentDarkmode} />
                             {/each}


### PR DESCRIPTION
Allows some components like `Title` to allow line breaks `\n` in the strings and preserve them.